### PR TITLE
Add a macro to <SpeakEasy.h> file

### DIFF
--- a/base/SpeakEasy.h
+++ b/base/SpeakEasy.h
@@ -83,6 +83,7 @@ unsigned long tmr_fast=0, tmr_slow=0;
 #define	SLOW_halfday()	if (!(phase_slow % 4321))
 #define	SLOW_1day()		if (!(phase_slow % 8641))
 
+#define EXECUTESPEEDY   else
 #define UPDATESPEEDY()	phase_speedy = (phase_speedy + 1) % num_phases
 #define	SPEEDY_x(n)		if (!(phase_speedy % n))
 

--- a/base/SpeakEasy.h
+++ b/base/SpeakEasy.h
@@ -83,7 +83,7 @@ unsigned long tmr_fast=0, tmr_slow=0;
 #define	SLOW_halfday()	if (!(phase_slow % 4321))
 #define	SLOW_1day()		if (!(phase_slow % 8641))
 
-#define EXECUTESPEEDY   else
+#define EXECUTESPEEDY() else
 #define UPDATESPEEDY()	phase_speedy = (phase_speedy + 1) % num_phases
 #define	SPEEDY_x(n)		if (!(phase_speedy % n))
 

--- a/examples/ethernet/e03_AnalogInput/e03_AnalogInput.ino
+++ b/examples/ethernet/e03_AnalogInput/e03_AnalogInput.ino
@@ -60,11 +60,13 @@ void setup()
 void loop()
 { 
     // Here we start to play
-    EXECUTEFAST() {                     
+    EXECUTEFAST()
+    {                     
         UPDATEFAST();   
         
         // Execute the logic to report the analog value to the user interface         
-        FAST_110ms() {
+        FAST_110ms()
+        {
             // Compare the acquired input with the stored one, send the new value to the
             // user interface if the difference is greater than the dead-band
             Read_AnalogIn(ANALOGDAQ);
@@ -73,12 +75,13 @@ void loop()
         // Process data communication
         FAST_GatewayComms();
     }
-else
+    EXECUTESPEEDY()
     {
         UPDATESPEEDY();
       
         // Execute the code every 3 times of free MCU       
-        SPEEDY_x(3) {
+        SPEEDY_x(3)
+        {
         
             // Acquire data from the microcontroller ADC
             AnalogIn(A0, ANALOGDAQ, 0.09, 0);   // The raw data is 0-1024, scaled as 0-100% without bias (100 / 1024 = 0.09)


### PR DESCRIPTION
Reviewing the "examples\ethernet\e03_AnalogInput.ino" example I encountered an "else" no "if" prior.
Seeking "SpeakEasy.h" I have seen that is not a bug, but I think people who start with Souliss may have trouble knowing that a "else" is needed before "UPDATESPEEDY".
I propose to add a "#define EXECUTESPEEDY()" to "SpeakEasy.h"
This would give uniformity to the programming and avoid a cause of errors.

The order for programming is:
EXECUTEFAST() { --code-- }
EXECUTESLOW() { --code-- } (only if required)
EXECUTESPEEDY() { --code-- } (only if required)
