### PR TITLE
Fixes and refactoring in usart examples

### DIFF
--- a/examples/usart/e01_GarageDoor_n1/e01_GarageDoor_n1.ino
+++ b/examples/usart/e01_GarageDoor_n1/e01_GarageDoor_n1.ino
@@ -46,16 +46,17 @@
 uint8_t ip_address[4]  = {192, 168, 1, 77};
 uint8_t subnet_mask[4] = {255, 255, 255, 0};
 uint8_t ip_gateway[4]  = {192, 168, 1, 1};
-#define Gateway_address 77
 #define myvNet_address  ip_address[3]       // The last byte of the IP address (77) is also the vNet address
+// Define the RS485 network configuration
 #define myvNet_subnet   0xFF00
-#define myvNet_supern   Gateway_address
 #define Gateway_RS485   0xCE01
 #define Peer_RS485      0xCE02
 
 #define GARAGEDOOR_NODE1            0                       
 #define GARAGEDOOR_NODE2            0   
 #define GARAGELIGHT_NODE2           1
+
+#define INPUT_PIN	2 // Use Pin2 as ON/OFF command
 
 void setup()
 {   
@@ -70,7 +71,7 @@ void setup()
     SetAsPeerNode(Peer_RS485, 1); 
     
     // Define inputs, outputs pins and pulldown
-    pinMode(2, INPUT);  // Hardware pulldown required
+	pinMode(INPUT_PIN, INPUT);  // Hardware pulldown required
     
 }
 
@@ -84,10 +85,10 @@ void loop()
         FAST_510ms() {
             
             // Use Pin2 as ON/OFF command
-            if(DigIn(2, Souliss_T2n_ToggleCmd, GARAGEDOOR_NODE1))
+            if(DigIn(INPUT_PIN, Souliss_T2n_ToggleCmd, GARAGEDOOR_NODE1))
             {
                 // Send data
-                Souliss_RemoteInput(Peer_address, GARAGEDOOR_NODE2, mInput(GARAGEDOOR_NODE1));
+                Souliss_RemoteInput(Peer_RS485, GARAGEDOOR_NODE2, mInput(GARAGEDOOR_NODE1));
                 Souliss_ResetInput(memory_map, GARAGEDOOR_NODE1);
             }
         } 

--- a/examples/usart/e01_GarageDoor_n2/e01_GarageDoor_n2.ino
+++ b/examples/usart/e01_GarageDoor_n2/e01_GarageDoor_n2.ino
@@ -33,17 +33,21 @@
 #include <SPI.h>
 #include "Souliss.h"
 
-// Define the network configuration according to your router settings
-#define Gateway_address 77
-#define myvNet_address  ip_address[3]       // The last byte of the IP address (77) is also the vNet address
+// Define the RS485 network configuration
 #define myvNet_subnet   0xFF00
-#define myvNet_supern   Gateway_address
 #define Gateway_RS485   0xCE01
 #define Peer_RS485      0xCE02
 
 #define GARAGEDOOR_NODE1            0                       
 #define GARAGEDOOR_NODE2            0   
 #define GARAGELIGHT_NODE2           1
+
+#define INPUTPIN_LIMIT_OPENING 2
+#define INPUTPIN_LIMIT_CLOSING 4
+
+#define OUTPUTPIN_LAMP 7
+#define OUTPUTPIN_OPENING 8
+#define OUTPUTPIN_CLOSING 9
 
 void setup()
 {   
@@ -57,12 +61,12 @@ void setup()
     Set_SimpleLight(GARAGELIGHT_NODE2);
     
     // Define inputs, outputs pins
-    pinMode(2, INPUT);                  // Hardware pulldown required
-    pinMode(3, INPUT);                  // Hardware pulldown required
+    pinMode(INPUTPIN_LIMIT_OPENING, INPUT);                  // Hardware pulldown required
+    pinMode(INPUTPIN_LIMIT_CLOSING, INPUT);                  // Hardware pulldown required
 
-    pinMode(7, OUTPUT); 
-    pinMode(8, OUTPUT);
-    pinMode(9, OUTPUT);
+    pinMode(OUTPUTPIN_LAMP, OUTPUT);
+    pinMode(OUTPUTPIN_OPENING, OUTPUT);
+    pinMode(OUTPUTPIN_CLOSING, OUTPUT);
 }
 
 void loop()
@@ -75,16 +79,16 @@ void loop()
         // cames directly from SoulissApp or the push-button located on the other node
         FAST_510ms() {
         
-            // Use Pin3 and Pin 4 as limit switches
-            DigIn(2, Souliss_T2n_LimSwitch_Open, GARAGEDOOR_NODE2);
-            DigIn(3, Souliss_T2n_LimSwitch_Close, GARAGEDOOR_NODE2);            
+            // Use Pin2 and Pin 4 as limit switches
+            DigIn(INPUTPIN_LIMIT_OPENING, Souliss_T2n_LimSwitch_Open, GARAGEDOOR_NODE2);
+            DigIn(INPUTPIN_LIMIT_CLOSING, Souliss_T2n_LimSwitch_Close, GARAGEDOOR_NODE2);
             
             // Execute the logic for door or gate
             Logic_GarageDoor(GARAGEDOOR_NODE1);
             
             // Use Pin8 and Pin9 to control the open and close command through relays
-            DigOut(8, Souliss_T2n_Coil_Open, GARAGEDOOR_NODE2); 
-            DigOut(9, Souliss_T2n_Coil_Close, GARAGEDOOR_NODE2);                
+            DigOut(OUTPUTPIN_OPENING, Souliss_T2n_Coil_Open, GARAGEDOOR_NODE2);
+            DigOut(OUTPUTPIN_CLOSING, Souliss_T2n_Coil_Close, GARAGEDOOR_NODE2);
         
         
             // If the door or gate is open / opening, switch ON the light
@@ -97,7 +101,7 @@ void loop()
             Logic_SimpleLight(GARAGELIGHT_NODE2);
             
             // Use Pin7 to control the light
-            DigOut(7, Souliss_T1n_OnCoil, GARAGELIGHT_NODE2);           
+            DigOut(OUTPUTPIN_LAMP, Souliss_T1n_OnCoil, GARAGELIGHT_NODE2);
         }
 
         // Process the communication, this include the command that are coming from SoulissApp


### PR DESCRIPTION
- Fixed compile errors
- Removed unused network configuration for peer node sketch
- Added defines for pin configuration
- Changed second input pin from 3 to 4 to avoid collision with TX_ENABLE pin in peer node sketch
