### PR TITLE
Add category to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,7 @@ author=Souliss Team
 maintainer=Souliss Team
 sentence=SmartHome Networking Framework
 paragraph=Build a network of multiple nodes over WiFi/Ethernet, Wireless and RS485 for your smart home. Runs on AVRs and ESP8266.
+category=Communication
 url=http://souliss.github.io
 architectures=avr,esp8266
 


### PR DESCRIPTION
Fixes the `WARNING: Category '' in library souliss is not valid. Setting to 'Uncategorized'` warning in Arduino IDE 1.6.6. If you disagree with my category choice I'm happy to change the category to any of the other [valid category values](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification) and squash to a single commit.
