### PR TITLE
Set default AP password to blank

### DIFF
--- a/base/NetworkSetup.cpp
+++ b/base/NetworkSetup.cpp
@@ -300,7 +300,7 @@ uint8_t Souliss_GetIPAddress(U8 timeout=20)
 */	
 /**************************************************************************/ 
 #if(MCU_TYPE == 0x02)	// Expressif ESP8266
-String Souliss_SetAccessPoint(const char ap_name[32] = "", const char ap_pass[32] = "soulissnode")
+String Souliss_SetAccessPoint(const char ap_name[32] = "", const char ap_pass[32] = "")
 {
 	uint8_t i;
 	uint8_t ipaddr[4];


### PR DESCRIPTION
Change AP default password from "soulissnode" to "" (blank).
Based on https://github.com/souliss/souliss/pull/276#event-777628392
"Introducing a default password will result in misleading behavior between actual and future releases." 
