### PR TITLE
T32 issue

### DIFF
--- a/base/T3n.cpp
+++ b/base/T3n.cpp
@@ -356,7 +356,7 @@ U8 Souliss_Logic_T32(U8 *memory_map, U8 slot, U8 *trigger)
 	if(memory_map[MaCaco_IN_s + slot] != Souliss_T3n_AirCon_RstCmd)	
 	{	
 		// If the input command is different from the last executed command, trig a change
-		if(memory_map[MaCaco_OUT_s + slot] != memory_map[MaCaco_IN_s + slot])  
+		if(memory_map[MaCaco_OUT_s + slot] != memory_map[MaCaco_IN_s + slot] || memory_map[MaCaco_OUT_s + slot + 1] != memory_map[MaCaco_IN_s + slot + 1])   
 		{
 			memory_map[MaCaco_AUXIN_s + slot] = Souliss_TRIGGED;
 			i_trigger = Souliss_TRIGGED;	// Trig change
@@ -373,7 +373,7 @@ U8 Souliss_Logic_T32(U8 *memory_map, U8 slot, U8 *trigger)
 		*/
 		
 		memory_map[MaCaco_IN_s + slot] = Souliss_T3n_AirCon_RstCmd;			// Reset
-			
+		memory_map[MaCaco_IN_s + slot] = Souliss_T3n_AirCon_RstCmd;			// Reset		
 	}	
 	
 	// Update the trigger


### PR DESCRIPTION
The T32 trigger was checking only the first slot signal (2 byte). It has to check all the 4 bytes of the signal otherwise it is not able to undestand correctly the new signal (i.e. if the signal is different from the previous for the temperature only that is on the last 2 bytes, the trigger will not be activated)