### PR TITLE
[PRODino WROOM] Inability to make SPI work when compiling on Linux

### DIFF
--- a/hardware/KMPElectronics/DINoWroom.h
+++ b/hardware/KMPElectronics/DINoWroom.h
@@ -97,8 +97,8 @@ const uint8_t RELAY_PINS[RELAY_COUNT] =
 const int OPTOIN_PINS[OPTOIN_COUNT] =
 { IN1PIN, IN2PIN, IN3PIN, IN4PIN };
 
-uint8_t  _expTxData[16];
-uint8_t  _expRxData[16];
+uint8_t  _expTxData[16] __attribute__((aligned(4)));
+uint8_t  _expRxData[16] __attribute__((aligned(4)));
 
 // User Methods
 #define	InitDINo()	DINoWroom_init()


### PR DESCRIPTION
solved by passing aligned ptrs to SPI::transferBytes.

Should also fix esp8266/Arduino#3315
