### PR TITLE
Consider a dimmer to be on when it was turned on using the increase value command

### DIFF
--- a/base/T1n.cpp
+++ b/base/T1n.cpp
@@ -1144,6 +1144,8 @@ U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 		if(memory_map[MaCaco_OUT_s + slot + 1] < 255 - Souliss_T1n_BrightValue)
 			memory_map[MaCaco_OUT_s + slot + 1] += Souliss_T1n_BrightValue;
 
+		memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OnCoil;
+
 		memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
 
 		i_trigger = Souliss_TRIGGED;
@@ -1151,8 +1153,16 @@ U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 	else if (memory_map[MaCaco_IN_s + slot] == Souliss_T1n_BrightDown)				// Decrease the light value
 	{
 		// Decrease the light value
-		if(memory_map[MaCaco_OUT_s + slot + 1] > Souliss_T1n_BrightValue)
+		if(memory_map[MaCaco_OUT_s + slot + 1] > Souliss_T1n_BrightValue){
 			memory_map[MaCaco_OUT_s + slot + 1] -= Souliss_T1n_BrightValue;
+		}else{
+			memory_map[MaCaco_OUT_s + slot + 1] = 0;
+			
+		}
+
+		if(memory_map[MaCaco_OUT_s + slot + 1] == 0){
+			memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OffCoil;
+		}
 
 		memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
 


### PR DESCRIPTION
When you turn on a dimmer by setting a dimm value or increasing from zero, it is considered to be off, this means that the next button press will turn it to the default value, when most of the times the user will want to turn it off.

This PR changes that behaviour.