### PR TITLE
fade in and out dimmer

### DIFF
--- a/base/T1n.cpp
+++ b/base/T1n.cpp
@@ -1144,6 +1144,8 @@ U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 		if(memory_map[MaCaco_OUT_s + slot + 1] < 255 - Souliss_T1n_BrightValue)
 			memory_map[MaCaco_OUT_s + slot + 1] += Souliss_T1n_BrightValue;
 
+		memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OnCoil;
+
 		memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
 
 		i_trigger = Souliss_TRIGGED;
@@ -1151,8 +1153,16 @@ U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 	else if (memory_map[MaCaco_IN_s + slot] == Souliss_T1n_BrightDown)				// Decrease the light value
 	{
 		// Decrease the light value
-		if(memory_map[MaCaco_OUT_s + slot + 1] > Souliss_T1n_BrightValue)
+		if(memory_map[MaCaco_OUT_s + slot + 1] > Souliss_T1n_BrightValue){
 			memory_map[MaCaco_OUT_s + slot + 1] -= Souliss_T1n_BrightValue;
+		}else{
+			memory_map[MaCaco_OUT_s + slot + 1] = 0;
+			
+		}
+
+		if(memory_map[MaCaco_OUT_s + slot + 1] == 0){
+			memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OffCoil;
+		}
 
 		memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
 

--- a/base/T1n.cpp
+++ b/base/T1n.cpp
@@ -1066,6 +1066,7 @@ void Souliss_SetT19(U8 *memory_map, U8 slot)
 		-  1(hex) for output ON.
 
 */
+long lastM=0L,startM=0L;
 /**************************************************************************/
 U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 {
@@ -1086,18 +1087,29 @@ U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 	}
 	else if ((memory_map[MaCaco_IN_s + slot] == Souliss_T1n_OffCmd))	// Off Command
 	{
+		U8 step_size=Souliss_T1n_BrightDefault/(1000/30);
+
 		// Trigger the change and save the actual color
-		if(memory_map[MaCaco_OUT_s + slot] != Souliss_T1n_OffCoil)
-		{
-			memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OffCoil;		// Switch off the light state
-			i_trigger = Souliss_TRIGGED;								// Trig the change
-		}
+		// if(memory_map[MaCaco_OUT_s + slot] != Souliss_T1n_OffCoil)
+		// {
+		// 	memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OffCoil;		// Switch off the light state
+		// 	i_trigger = Souliss_TRIGGED;								// Trig the change
+		// }
 
 		// Fade out and turn off the light step wise
-			while(memory_map[MaCaco_OUT_s + slot + 1])
-				memory_map[MaCaco_OUT_s + slot + 1]--;
+			//while(memory_map[MaCaco_OUT_s + slot + 1])
+			//	memory_map[MaCaco_OUT_s + slot + 1]--;
+		if(memory_map[MaCaco_OUT_s + slot + 1]>step_size){
+			memory_map[MaCaco_OUT_s + slot + 1]-=step_size;
+		}else{
+			memory_map[MaCaco_OUT_s + slot + 1]=0;
+		}
 
-		memory_map[MaCaco_IN_s + slot]    = Souliss_T1n_RstCmd;		// Reset
+		if(memory_map[MaCaco_OUT_s + slot] != Souliss_T1n_OffCoil && memory_map[MaCaco_OUT_s + slot + 1]==0) {
+			memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OffCoil;		// Switch off the light state
+			i_trigger = Souliss_TRIGGED;								// Trig the change
+			memory_map[MaCaco_IN_s + slot]    = Souliss_T1n_RstCmd;		// Reset
+		}
 	}
 	else if (memory_map[MaCaco_IN_s + slot] == Souliss_T1n_OnCmd)
 	{
@@ -1105,24 +1117,60 @@ U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 			i_trigger = Souliss_TRIGGED;
 
 		memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OnCoil;			// Switch on the output
+	
+		// long m=millis();
+		// 	if(startM==0L){
+		// 		lastM=millis();
+		// 		startM=millis();
+		// 	}else{
+				
+		// 		 Serial.print("Total:");
+		// 		 Serial.println(m-startM);
+		// 		 Serial.print("Step:");
+		// 		 Serial.println(m-lastM);
+		// 	}
+		U8 step_size=Souliss_T1n_BrightDefault/(1000/30);
 
-		// If there were no color set, use a light white
-		if((memory_map[MaCaco_AUXIN_s + slot + 1] == 0))
-		{
-			while(memory_map[MaCaco_OUT_s + slot + 1] < Souliss_T1n_BrightDefault)	// Set a light white
-				memory_map[MaCaco_OUT_s + slot + 1]++;
-
+		// If there weas no value set, set it to the default
+		if((memory_map[MaCaco_AUXIN_s + slot + 1] == 0)){
 			memory_map[MaCaco_AUXIN_s + slot + 1] = Souliss_T1n_BrightDefault;
-			memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
 		}
-		else
-		{
-			// Fade in to the last color
-			while(memory_map[MaCaco_OUT_s + slot + 1] < (memory_map[MaCaco_AUXIN_s + slot + 1]))
-				memory_map[MaCaco_OUT_s + slot + 1]++;
+			
+		// memory_map[MaCaco_AUXIN_s + slot + 1] = Souliss_T1n_BrightDefault;
+		// memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
+		
+		// Fade in to the last brightness
+		
+
+		//Handle limits		
+		if(memory_map[MaCaco_OUT_s + slot + 1] > memory_map[MaCaco_AUXIN_s + slot + 1] ||//Edge case where the current value is higher than the target 
+			memory_map[MaCaco_AUXIN_s + slot + 1] < step_size || 							 //Or the step size is bigger than the target
+			(memory_map[MaCaco_AUXIN_s + slot + 1] - memory_map[MaCaco_OUT_s + slot + 1]) < step_size	//Case where there's less than a step remaining
+			){
+			memory_map[MaCaco_OUT_s + slot + 1] = memory_map[MaCaco_AUXIN_s + slot + 1];
+		}else{
+			//increase a step and make sure to not overflow
+			if(memory_map[MaCaco_OUT_s + slot + 1] <= (memory_map[MaCaco_AUXIN_s + slot + 1]-step_size)){
+				memory_map[MaCaco_OUT_s + slot + 1] += step_size;
+			}
 		}
 
-		memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
+		
+		if(memory_map[MaCaco_OUT_s + slot + 1] >= (memory_map[MaCaco_AUXIN_s + slot + 1])){
+			memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset			
+			// Serial.print("Total:");
+			// Serial.println(m-startM);
+			// Serial.print("Step:");
+			// Serial.println(m-lastM);
+			// lastM=0L;
+			// startM=0L;
+		}
+		
+		//lastM=m;
+		// Serial.print("Level - ");
+		// Serial.print(slot);
+		// Serial.print(":");
+		// Serial.println(memory_map[MaCaco_OUT_s + slot + 1]);
 	}
 	else if (memory_map[MaCaco_IN_s + slot] == Souliss_T1n_BrightSwitch)		// Toggle Bright
 	{
@@ -1140,12 +1188,24 @@ U8 Souliss_Logic_T19(U8 *memory_map, U8 slot, U8 *trigger)
 	}
 	else if (memory_map[MaCaco_IN_s + slot] == Souliss_T1n_BrightUp)		// Increase the light value
 	{
+		U8 step_size=Souliss_T1n_BrightDefault/(3000/30);
+
 		// Increase the light value
-		if(memory_map[MaCaco_OUT_s + slot + 1] < 255 - Souliss_T1n_BrightValue)
-			memory_map[MaCaco_OUT_s + slot + 1] += Souliss_T1n_BrightValue;
+//		if(memory_map[MaCaco_OUT_s + slot + 1] < 255 - Souliss_T1n_BrightValue)
+//			memory_map[MaCaco_OUT_s + slot + 1] += Souliss_T1n_BrightValue;
+
+		// Increase the light value
+		if(memory_map[MaCaco_OUT_s + slot + 1] < (255 - step_size)){
+			memory_map[MaCaco_OUT_s + slot + 1] += step_size;
+		} else {
+			memory_map[MaCaco_OUT_s + slot + 1] = 255;
+		}
+		//Serial.println(memory_map[MaCaco_OUT_s + slot + 1]);
+
+		//Set the default intensity
+		memory_map[MaCaco_AUXIN_s + slot + 1] = memory_map[MaCaco_OUT_s + slot + 1];
 
 		memory_map[MaCaco_OUT_s + slot] = Souliss_T1n_OnCoil;
-
 		memory_map[MaCaco_IN_s + slot] = Souliss_T1n_RstCmd;			// Reset
 
 		i_trigger = Souliss_TRIGGED;


### PR DESCRIPTION
All edits are in `base/T1n.cpp`, in `Souliss_Logic_T19` (typical T19: single-channel dimmer). They replace instant brightness changes with time-based, stepped fades so the firmware doesn’t block and the light fades over a fixed duration.

  ────────────────────────────────────────

  1. **Off command (fade-out)**

  Before:
  • Output was set to OFF and trigger fired immediately.
  • Brightness was ramped to zero in a single call with a while loop (memory_map[MaCaco_OUT_s + slot + 1]--), which could block for many logic cycles.

  After:
  • Step-based fade-out: each time the logic runs, brightness is reduced by

    step_size = Souliss_T1n_BrightDefault / (1000/30) (≈ 5 with default 0xAA and ~30 ms cycle).
  • Output is set to OFF and command is reset only when brightness has reached 0.
  • So “Off” now produces a ~1 s fade-out (about 33 steps × 30 ms) instead of an instant off and no blocking loop.

  ────────────────────────────────────────

  2. **On command (fade-in)**

  Before:
  • Output set to ON immediately.
  • If no previous level: brightness was ramped in one go with a while loop up to Souliss_T1n_BrightDefault.
  • If there was a saved level: another while ramped up to that level.
  • Again, one logic call could block for many cycles.

  After:
  • Output is set to ON immediately, but brightness ramps in steps using the same step_size as fade-out (Souliss_T1n_BrightDefault/(1000/30)).
  • If no target is set, target is set to Souliss_T1n_BrightDefault.
  • Each call: increase current brightness by step_size toward the target, with clamp/edge handling (target already reached, step larger than remaining, etc.).
  • Command is reset only when current brightness ≥ target.
  • Result: ~1 s fade-in to the default or last-set level, without blocking.

  ────────────────────────────────────────

  3. **BrightUp command**

  Before:
  • Single step of Souliss_T1n_BrightValue (0x10) per command.
  • No notion of “fade over time”.

  After:
  • step_size = Souliss_T1n_BrightDefault / (3000/30) → about 1 per step with default (0xAA).
  • Brightness increases by that step each logic cycle (capped at 255).
  • `MaCaco_AUXIN_s + slot + 1` is set to the new level so that the next “On” will fade in to this level.
  • Over ~3 s (3000/30 ≈ 100 steps) you get a smooth ramp up when holding BrightUp.

  ────────────────────────────────────────

  4. **Global variables and debug**

  • Added: long lastM=0L, startM=0L; at file scope.
  • Commented out: Serial.print / Serial.println and uses of lastM/startM (timing debug for fade).
  • So the new globals are unused; they can be removed if you don’t plan to re-enable that debug.

  ────────────────────────────────────────

  Behaviour in short

  | Command  | Before                          | After                                                       |
  |----------|---------------------------------|-------------------------------------------------------------|
  | Off      | Instant off + blocking fade-out | ~1 s step-based fade-out, non-blocking                      |
  | On       | Instant on + blocking fade-in   | ~1 s step-based fade-in, non-blocking                       |
  | BrightUp | Fixed step (0x10) per press     | Smaller time-based step; also updates “default” for next On |

  Constants used: Souliss_T1n_BrightDefault = 0xAA, logic cycle ~30 ms. So 1 s for on/off fades and ~3 s for the BrightUp ramp. The main behavioral change is non-blocking, time-based dimming instead of instant changes and blocking while
  loops.